### PR TITLE
fix: xcom clear

### DIFF
--- a/dags/Renewable_energy_generation.py
+++ b/dags/Renewable_energy_generation.py
@@ -174,7 +174,7 @@ def update_state(**kwargs):
         success = result
 
     if success == True:
-        task_instance.xcom_delete(key='http_request_state')
+        XCom.clear(key='http_request_state')
         logging.info("State deleted")
     else:
         # success == False인 경우 상태를 업데이트


### PR DESCRIPTION
task_instance.xcom_delete(key='http_request_state') 에서 xcom_delete라는 메서드는 존재하지 않음

XCom.clear 메서드를 사용

task_id랑 dag_id를 꼭 포함할 필요는 없지만 해당 매개변수를 사용할 경우 특정 범위 내에서만 XCom 항목을 삭제할 수 있음
