### PR TITLE
fix: xcom_clear error

### DIFF
--- a/dags/Renewable_energy_generation.py
+++ b/dags/Renewable_energy_generation.py
@@ -39,7 +39,7 @@ def get_or_initialize_state(**kwargs):
             'success': None
         }
         # 초기 상태를 XCom에 저장
-        task_instance.xcom_push(key='http_request_state', value=state)
+        task_instance.xcom_push(key='http_request_state', value=state, task_ids='get_state')
     logging.info(f"State: {state}")
 
 
@@ -174,7 +174,10 @@ def update_state(**kwargs):
         success = result
 
     if success == True:
-        XCom.clear(key='http_request_state')
+        XCom.clear(
+            task_ids=['get_state', 'extract', 'update_state'],
+            dag_id='net-project-ETL', 
+            execution_date=execution_date)
         logging.info("State deleted")
     else:
         # success == False인 경우 상태를 업데이트
@@ -184,7 +187,7 @@ def update_state(**kwargs):
             'request_count': REQUEST_COUNT,
             'success': success
         }
-        task_instance.xcom_push(key='http_request_state', value=state)
+        task_instance.xcom_push(key='http_request_state', value=state, task_ids='update_state')
         logging.info(f"State: {state}")
 
 


### PR DESCRIPTION
Xcom.clear() 메서드를 쓸 때

TypeError: clear() got an unexpected keyword argument 'key' 에러가 발생함

해당 매개변수로는 key값을 안주고 task_ids 값과 dag_id 값 그리고 execution_date 값을 지정해서 Xcom을 clear 하게 함

xcom은 각각 task 마다 상태 정보를 저장 문에 
어디에서 사용되고 있는 정보인지 알기 위해서는 직관적으로 task_id를 지정해주는게 좋은 것 같음
