### PR TITLE
Fix/extract

### DIFF
--- a/dags/Renewable_energy_generation.py
+++ b/dags/Renewable_energy_generation.py
@@ -187,7 +187,7 @@ def update_state(**kwargs):
             'request_count': REQUEST_COUNT,
             'success': success
         }
-        task_instance.xcom_push(key='http_request_state', value=state, task_ids='update_state')
+        task_instance.xcom_push(key='http_request_state', value=state)
         logging.info(f"State: {state}")
 
 

--- a/dags/Renewable_energy_generation.py
+++ b/dags/Renewable_energy_generation.py
@@ -39,7 +39,7 @@ def get_or_initialize_state(**kwargs):
             'success': None
         }
         # 초기 상태를 XCom에 저장
-        task_instance.xcom_push(key='http_request_state', value=state, task_ids='get_state')
+        task_instance.xcom_push(key='http_request_state', value=state)
     logging.info(f"State: {state}")
 
 


### PR DESCRIPTION
Xcom push 메서드는 일반적으로 key value 매개변수를 받지만 task_ids 매개변수는 받지 않음

task_ids 매개변수는 xcom_pull 메서드에서 사용되며 여러 태스크에 걸친 XCom 값을 검색하는 데 사용함

xcom_push에서는 필요하지 않음