### PR TITLE
fix: xcom clear error

### DIFF
--- a/dags/Renewable_energy_generation.py
+++ b/dags/Renewable_energy_generation.py
@@ -175,6 +175,7 @@ def update_state(**kwargs):
 
     if success == True:
         XCom.clear(
+            task_id='get_state',
             dag_id='net-project-ETL', 
             execution_date=kwargs['execution_date'])
         logging.info("State deleted")


### PR DESCRIPTION
xcom clear 메서드를 사용할떄 task_id는 꼭 지정해줘야함